### PR TITLE
Correctly return finished

### DIFF
--- a/coroutine.h
+++ b/coroutine.h
@@ -164,7 +164,7 @@ inline int resume(routine_t id)
 		SwitchToFiber(routine->fiber);
 	}
 
-	return 0;
+	return routine->finished ? -2 : 0;
 }
 
 inline void yield()
@@ -346,7 +346,7 @@ inline int resume(routine_t id)
 		swapcontext(&ordinator.ctx, &routine->ctx);
 	}
 
-	return 0;
+	return routine->finished ? -2 : 0;
 }
 
 inline void yield()


### PR DESCRIPTION
Hi,

I think this change makes the behavior of resume more semantically correct.

Consider the following code 

```c++
void routine_func()
{
    std::cout << "step1" << std::endl;
    coroutine::yield();

    std::cout << "step2" << std::endl;
    coroutine::yield();

    std::cout << "step3"<< std::endl;
    coroutine::yiel3();

     std::cout << "done" << std::endl;
}

int main()
{
    coroutine::routine_t rt = coroutine::create(routine_func);

    std::cout << coroutine::resume(rt) << std::endl;
    std::cout << coroutine::resume(rt) << std::endl;
    std::cout << coroutine::resume(rt) << std::endl;
    std::cout << coroutine::resume(rt) << std::endl;

   return 0;
}
```

I think it is reasonable to expect an output  like 

```
step1
0
step2
0
step3
0
done
-2
```

I would also suggest to add an enum like this

```c++
enum ResumeResult{
    INVALID = -1,
    FINISHED = -2,
    YIELD = 0
};
```

Cheers

Davide